### PR TITLE
Forcing views to be published.

### DIFF
--- a/src/Commands/LaralumPublish.php
+++ b/src/Commands/LaralumPublish.php
@@ -67,6 +67,7 @@ class LaralumPublish extends Command
                     if ($pr) {
                         $this->callSilent('vendor:publish', [
                             '--provider' => $pr,
+                            '--force' => true,
                         ]);
                     }
                 }


### PR DESCRIPTION
When I updated to Laralum v1.1.0 the view did not get published with `laralum:publish`, so I added the force option. Works now.